### PR TITLE
Outlining

### DIFF
--- a/packages/components/src/Form/FieldRte/FieldRte.tsx
+++ b/packages/components/src/Form/FieldRte/FieldRte.tsx
@@ -280,7 +280,7 @@ export const FieldRte = ({
                 })}>
                 <div
                     className={classNames('relative rounded border', {
-                        'bg-pzh-gray-100': disabled,
+                        'bg-pzh-gray-200': disabled,
                         'bg-pzh-white': !disabled,
                         'pzh-form-error': hasError,
                         'border-pzh-gray-600': !hasError,

--- a/packages/css/src/tailwind.src.css
+++ b/packages/css/src/tailwind.src.css
@@ -7,6 +7,7 @@
   src: url("./../fonts/Karbon-Regular.woff2") format("woff2");
   font-weight: normal;
   font-display: swap;
+  ascent-override: 90%;
 }
 
 @font-face {
@@ -14,6 +15,7 @@
   src: url("./../fonts/Karbon-Medium.woff2") format("woff2");
   font-weight: bold;
   font-display: swap;
+  ascent-override: 90%;
 }
 
 html {


### PR DESCRIPTION
Eigenlijk maar 2 kleine fixes.

De background van de disabled FieldRte hetzelfde gemaakt als andere Field velden.
Line height verschil tussen Mac en Windows opgelost door ascent-override toe te voegen aan de font-face. Zou verkeerde lining tussen Mac en Windows moeten oplossen:
MacOs:
![image](https://github.com/user-attachments/assets/809a9e30-c3b0-4ac2-9909-6118e66048e9)
Windows:
![image](https://github.com/user-attachments/assets/42fc3d90-d74c-46eb-9ae3-671cc9f8b921)

